### PR TITLE
Printing error if no target is specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -596,6 +596,10 @@ func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	flag.Parse()
+	if flag.Arg(0) == "" {
+		fmt.Fprintf(os.Stderr, "Must specify a target\n")
+		return
+	}
 	target := flag.Arg(0)
 
 	var probes []chan interface{}


### PR DESCRIPTION
The default invocation doesn't warn if no target is passed, it just crashes. This patch fixes this behaviour