### PR TITLE
Replace syscalls with x/net/{icmp,ipv4,ipv6}

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,8 +126,9 @@ func TCPReceiver(done <-chan struct{}, af string, srcAddr net.IP, targetAddr str
 	// IP + TCP header, this channel is fed from the socket
 	recv := make(chan TCPResponse)
 	go func() {
-		ipHdrSize := 0
+		ipHdrSize := 0 // no IPv6 header present on TCP packets received on the raw socket
 		if af == "ip4" {
+			// IPv4 header is always included with the ipv4 raw socket receive
 			ipHdrSize = minIP4HeaderSize
 		}
 		packet := make([]byte, ipHdrSize+maxTCPHdrSize)

--- a/tcp.go
+++ b/tcp.go
@@ -44,7 +44,7 @@ type TCPHeader struct {
 //
 // create & serialize a TCP header, compute and fill in the checksum (v4/v6)
 //
-func makeTCPHeader(af string, srcAddr, dstAddr *net.IP, srcPort, dstPort int, ts uint32) []byte {
+func makeTCPHeader(af string, srcAddr, dstAddr net.IP, srcPort, dstPort int, ts uint32) []byte {
 	tcpHeader := TCPHeader{
 		Source:      uint16(srcPort), // Random ephemeral port
 		Destination: uint16(dstPort),
@@ -121,13 +121,13 @@ func (tcp *TCPHeader) Serialize() []byte {
 //
 // TCP Checksum, works for both v4 and v6 IP addresses
 //
-func tcpChecksum(af string, data []byte, srcip, dstip *net.IP) uint16 {
+func tcpChecksum(af string, data []byte, srcip, dstip net.IP) uint16 {
 
 	// the pseudo header used for TCP c-sum computation
 	var pseudoHeader []byte
 
-	pseudoHeader = append(pseudoHeader, *srcip...)
-	pseudoHeader = append(pseudoHeader, *dstip...)
+	pseudoHeader = append(pseudoHeader, srcip...)
+	pseudoHeader = append(pseudoHeader, dstip...)
 	switch {
 	case af == "ip4":
 		pseudoHeader = append(pseudoHeader, []byte{


### PR DESCRIPTION
This improves cross platform compatibility.

Partially resolves #7. fbtracert can be compiled for Windows, but will only function on server versions. Writing TCP packets to a raw socket is restricted on desktop version of Windows (see _Limitations of Raw Sockets_ [here](https://msdn.microsoft.com/en-us/library/windows/desktop/ms740548%28v=vs.85%29.aspx)). Windows also does not support setting traffic class via syscalls, with this PR fbtracert will log a message to that effect and continue with the default traffic class.

Additionally, the receive buffer sizes were increased. Windows throws an error if the buffer is not large enough to fit the entire packet.

As I was adding the srcAddr params to `TCPReceiver` and `ICMPReceiver` I took the liberty of changing instance of `*net.IP` to `net.IP`. `net.IP` is a `[]byte`. Since slices are themselves pointers, having a pointer to a slice is unnecessary.

Split off from #9.
